### PR TITLE
Compacted group-by utils code

### DIFF
--- a/app/utils/group-by.js
+++ b/app/utils/group-by.js
@@ -7,16 +7,16 @@ export default function(groupBy) {
     var result = [];
 
     this.get('content').forEach(function(item){
-      var hasGroup = !!result.findBy('group', get(item, groupBy));
+      var existentGroup = result.findBy('group', get(item, groupBy));
 
-      if (!hasGroup) {
+      if (!existentGroup) {
         result.pushObject(Ember.Object.create({
           group: get(item, groupBy),
           content: []
         }));
       }
 
-      result.findBy('group', get(item, groupBy)).get('content').pushObject(item);
+      existentGroup.get('content').pushObject(item);
     });
 
     return result;


### PR DESCRIPTION
Removed duplicated findBy calls by using the already existent property that
holds the results of the findBy operation.
